### PR TITLE
add allow-empty-class to `no-unnecessary-class`

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -3,7 +3,8 @@
     "no-unnecessary-class": [
       true,
       "allow-constructor-only",
-      "allow-static-only"
+      "allow-static-only",
+      "allow-empty-class"
     ],
     "member-access": [
       true,


### PR DESCRIPTION
Feature as described in #13

** What is the new behavior?
No lint error on empty classes

** Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```